### PR TITLE
Patch to fix implicit declaration warning/error

### DIFF
--- a/src/objects.h
+++ b/src/objects.h
@@ -49,4 +49,6 @@ void draw (struct Object o, char facing);
 /* Checks for collision between a player object and a target */
 int collision (struct Object player, struct Object target);
 
+void setupColors ();
+
 #endif


### PR DESCRIPTION
When compiling gnuski on macOS sonoma, the following error is raised due to an implicit declaration:

```
gcc -O2 -o gnuski main.c objects.c -lncurses
main.c:45:3: error: call to undeclared function 'setupColors'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
setupColors ();
^
```

This patches fixes this issue.

Originally created on 2023-10-15 by Thierry Moisan: https://sourceforge.net/p/gnuski/patches/2/